### PR TITLE
Use raw identifiers for type attribute

### DIFF
--- a/rustac-core/src/lib.rs
+++ b/rustac-core/src/lib.rs
@@ -111,7 +111,7 @@
 //!   let item: Item = serde_json::from_value(example)?;
 //!
 //!   assert_eq!(item.stac_version, Version::parse("1.0.0-rc.2")?);
-//!   assert_eq!(item.type_, String::from("Feature"));
+//!   assert_eq!(item.r#type, String::from("Feature"));
 //!
 //!   Ok(())
 //! }

--- a/rustac-core/src/types/catalog.rs
+++ b/rustac-core/src/types/catalog.rs
@@ -14,8 +14,7 @@ pub struct Catalog {
 
     /// Set to Catalog if this Catalog only implements the Catalog spec.
     /// **This maps to the STAC `"type"` attribute, which is a reserved keyword.**
-    #[serde(rename = "type")]
-    pub type_: String,
+    pub r#type: String,
 
     /// A list of extension identifiers the Catalog implements.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rustac-core/src/types/collection.rs
+++ b/rustac-core/src/types/collection.rs
@@ -18,8 +18,7 @@ pub struct Collection {
 
     /// Must be set to `"Collection"` to be a valid Collection.
     /// **This maps to the STAC `"type"` attribute, which is a reserved keyword.**
-    #[serde(rename = "type")]
-    pub type_: String,
+    pub r#type: String,
 
     /// A list of extension identifiers the Collection implements.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rustac-core/src/types/common.rs
+++ b/rustac-core/src/types/common.rs
@@ -91,9 +91,8 @@ pub struct Asset {
     /// [Media type](https://github.com/radiantearth/stac-spec/blob/v1.0.0-rc.1/item-spec/item-spec.md#asset-media-type) of the asset.
     /// See the [common media types](https://github.com/radiantearth/stac-spec/blob/v1.0.0-rc.1/best-practices.md#common-media-types-in-stac)
     /// in the best practice doc for commonly used asset types.
-    #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub type_: Option<String>,
+    pub r#type: Option<String>,
 
     /// The [semantic roles](https://github.com/radiantearth/stac-spec/blob/v1.0.0-rc.1/item-spec/item-spec.md#asset-role-types) of the asset,
     /// similar to the use of rel in links.
@@ -122,9 +121,8 @@ pub struct Link {
     pub rel: String,
 
     /// [Media type](https://github.com/radiantearth/stac-spec/blob/v1.0.0-rc.1/catalog-spec/catalog-spec.md#media-types) of the referenced entity.
-    #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub type_: Option<String>,
+    pub r#type: Option<String>,
 
     /// A human readable title to be used in rendered displays of the link.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rustac-core/src/types/item.rs
+++ b/rustac-core/src/types/item.rs
@@ -24,8 +24,7 @@ pub struct Item {
     pub id: String,
 
     /// Type of the GeoJSON Object. MUST be set to `"Feature"`.
-    #[serde(rename = "type")]
-    pub type_: String,
+    pub r#type: String,
 
     /// Defines the full footprint of the asset represented by this item. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on WGS 84.
     pub geometry: Geometry,


### PR DESCRIPTION
All STAC objects have a `type` property, but `type` is a reserved keyword in Rust, so we cannot use it directly as a field name in the structs. I got around this initially by naming the field `type_`, but this seems a bit awkward since it breaks the typical naming convention and requires a user to use something like `Collection.type_`, which might not be obvious

This PR uses [raw identifiers](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/raw-identifiers.html) instead of changing the field name, so the usage looks more like `Collection.r#type`. Still not ideal, but it also has the advantage of not requiring an artificial `#[serde(rename = "type")]` attribute everywhere we serialize/deserialize a `type` field.